### PR TITLE
fix(ios): resolve native DoordeckSDK via Swift Package Manager

### DIFF
--- a/HeadlessReactNativeSdk.podspec
+++ b/HeadlessReactNativeSdk.podspec
@@ -18,8 +18,15 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
   s.preserve_paths = "ios/**/*.{h,m,mm,swift}"
 
-  doordeck_sdk_version = '0.86'
-  s.dependency "DoordeckSDK", "~> #{doordeck_sdk_version}"
+  # The native Doordeck SDK is distributed as a Swift Package (a binary xcframework),
+  # not as a CocoaPods pod. Wire it in via React Native's built-in SPM support
+  # (spm_dependency, available on RN >= 0.76). The SPM product/module is "DoordeckSDK",
+  # so `import DoordeckSDK` in the Swift bridge continues to work unchanged.
+  spm_dependency(s,
+    url: 'https://github.com/doordeck/doordeck-headless-sdk-spm.git',
+    requirement: { kind: 'upToNextMajorVersion', minimumVersion: '1.156.0' },
+    products: ['DoordeckSDK']
+  )
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "build:android": "react-native build-android --extra-params \"--no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a\"",
-    "build:ios": "react-native build-ios --scheme HeadlessReactNativeSdkExample --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\""
+    "build:ios": "react-native build-ios --scheme HeadlessReactNativeSdkExample --mode Debug --extra-params \"-sdk iphonesimulator EXCLUDED_ARCHS=x86_64 CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\""
   },
   "dependencies": {
     "@react-navigation/native": "^7.0.14",

--- a/ios/HeadlessReactNativeSdkImpl.swift
+++ b/ios/HeadlessReactNativeSdkImpl.swift
@@ -106,9 +106,7 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     Task {
       do {
         let sdk = try await self.sdk()
-        guard let response = try await sdk.account().getUserDetails() else {
-          throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
-        }
+        let response = try await sdk.account().getUserDetails()
         let contextManager = sdk.contextManager()
         let tokenAboutToExpire = try await contextManager.isCloudAuthTokenInvalidOrExpired(checkServerInvalidation: false)
         resolver(response.toNativeMap(

--- a/ios/HeadlessReactNativeSdkImpl.swift
+++ b/ios/HeadlessReactNativeSdkImpl.swift
@@ -12,12 +12,19 @@ import DoordeckSDK
 @objc(HeadlessReactNativeSdkImpl)
 public class HeadlessReactNativeSdkImpl: NSObject {
 
-  private let doordeckSdk: Doordeck
+  // The Doordeck SDK is now initialized through an async/throwing factory, which
+  // cannot run in `init()`. Initialize it lazily on first use and cache it.
+  private var doordeckSdk: Doordeck?
 
-  override public init() {
-    self.doordeckSdk = KDoordeckFactory().initialize(sdkConfig: SdkConfig.Builder().build())
-
-    super.init()
+  private func sdk() async throws -> Doordeck {
+    if let existing = doordeckSdk {
+      return existing
+    }
+    guard let initialized = try await KDoordeckFactory().initialize(sdkConfig: SdkConfig.Builder().build()) else {
+      throw HeadlessReactNativeSdkImpl.makeError("Failed to initialize the Doordeck SDK")
+    }
+    doordeckSdk = initialized
+    return initialized
   }
 
   /**
@@ -30,16 +37,14 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    setKeyPairIfNeeded()
-
-    doordeckSdk.accountless().login(email: email, password: password) { tokenResponse, error in
-
-      if let error = error {
+    Task {
+      do {
+        let sdk = try await self.sdk()
+        self.setKeyPairIfNeeded(sdk)
+        _ = try await sdk.accountless().login(email: email, password: password)
+        try await self.respondNeedsVerification(sdk, resolver)
+      } catch {
         rejecter("LOGIN_ERROR", error.localizedDescription, error)
-      } else if tokenResponse != nil {
-        self.respondNeedsVerification(resolver, rejecter)
-      } else {
-        rejecter("LOGIN_ERROR", "Unknown error occurred", nil)
       }
     }
   }
@@ -49,10 +54,16 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    setKeyPairIfNeeded()
-
-    doordeckSdk.contextManager().setCloudAuthToken(token: authToken)
-    self.respondNeedsVerification(resolver, rejecter)
+    Task {
+      do {
+        let sdk = try await self.sdk()
+        self.setKeyPairIfNeeded(sdk)
+        sdk.contextManager().setCloudAuthToken(token: authToken)
+        try await self.respondNeedsVerification(sdk, resolver)
+      } catch {
+        rejecter("SET_AUTH_TOKEN_ERROR", error.localizedDescription, error)
+      }
+    }
   }
 
   @objc public func verify(
@@ -60,11 +71,13 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    doordeckSdk.account().verifyEphemeralKeyRegistration(code: code, privateKey: nil) { _, error in
-      if let error = error {
-        rejecter("VERIFY_ERROR", error.localizedDescription, error)
-      } else {
+    Task {
+      do {
+        let sdk = try await self.sdk()
+        _ = try await sdk.account().verifyEphemeralKeyRegistration(code: code, publicKey: nil, privateKey: nil)
         resolver(nil)
+      } catch {
+        rejecter("VERIFY_ERROR", error.localizedDescription, error)
       }
     }
   }
@@ -73,11 +86,13 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     _ resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    doordeckSdk.account().logout() { error in
-      if let error = error {
-        rejecter("LOGOUT_ERROR", error.localizedDescription, error)
-      } else {
+    Task {
+      do {
+        let sdk = try await self.sdk()
+        try await sdk.account().logout()
         resolver(nil)
+      } catch {
+        rejecter("LOGOUT_ERROR", error.localizedDescription, error)
       }
     }
   }
@@ -90,17 +105,21 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     _ resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    doordeckSdk.account().getUserDetails { response, error in
-      if let error = error {
-        rejecter("USER_DETAILS_ERROR", error.localizedDescription, error)
-      } else if let response = response {
+    Task {
+      do {
+        let sdk = try await self.sdk()
+        guard let response = try await sdk.account().getUserDetails() else {
+          throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
+        }
+        let contextManager = sdk.contextManager()
+        let tokenAboutToExpire = try await contextManager.isCloudAuthTokenInvalidOrExpired(checkServerInvalidation: false)
         resolver(response.toNativeMap(
-          userId: self.doordeckSdk.contextManager().getUserId(),
-          certificateChainAboutToExpire: self.doordeckSdk.contextManager().isCertificateChainAboutToExpire(),
-          tokenAboutToExpire: self.doordeckSdk.contextManager().isCloudAuthTokenAboutToExpire()
+          userId: contextManager.getUserId()?.uuidString,
+          certificateChainAboutToExpire: contextManager.isCertificateChainInvalidOrExpired(),
+          tokenAboutToExpire: tokenAboutToExpire?.boolValue ?? false
         ))
-      } else {
-        rejecter("USER_DETAILS_ERROR", "Unknown error occurred", nil)
+      } catch {
+        rejecter("USER_DETAILS_ERROR", error.localizedDescription, error)
       }
     }
   }
@@ -114,13 +133,18 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    doordeckSdk.tiles().getLocksBelongingToTile(tileId: tileId) { response, error in
-      if let error = error {
-        rejecter("LOCKS_ERROR", error.localizedDescription, error)
-      } else if let response = response {
+    Task {
+      do {
+        guard let tileUuid = UUID(uuidString: tileId) else {
+          throw HeadlessReactNativeSdkImpl.makeError("Invalid tileId: \(tileId)")
+        }
+        let sdk = try await self.sdk()
+        guard let response = try await sdk.tiles().getLocksBelongingToTile(tileId: tileUuid) else {
+          throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
+        }
         resolver(response.toNativeMap())
-      } else {
-        rejecter("LOCKS_ERROR", "Unknown error occurred", nil)
+      } catch {
+        rejecter("LOCKS_ERROR", error.localizedDescription, error)
       }
     }
   }
@@ -130,48 +154,58 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
-    let baseOperation = LockOperations.BaseOperation(
-      userId: nil,
-      userCertificateChain: nil,
-      userPrivateKey: nil,
-      lockId: lockId,
-      notBefore: Int32(Date().timeIntervalSince1970), // val notBefore: Int = Clock.System.now().epochSeconds.toInt(),
-      issuedAt: Int32(Date().timeIntervalSince1970), // val issuedAt: Int = Clock.System.now().epochSeconds.toInt(),
-      expiresAt: Int32(Date().addingTimeInterval(60).timeIntervalSince1970), // val expiresAt: Int = (Clock.System.now() + 1.minutes).epochSeconds.toInt(),
-      jti: UUID().uuidString // val jti: String = Uuid.random().toString()
-    )
+    Task {
+      do {
+        guard let lockUuid = UUID(uuidString: lockId) else {
+          throw HeadlessReactNativeSdkImpl.makeError("Invalid lockId: \(lockId)")
+        }
+        let sdk = try await self.sdk()
 
-    let unlockOperation = LockOperations.UnlockOperation(baseOperation: baseOperation, directAccessEndpoints: nil)
+        let now = Date()
+        let baseOperation = LockOperations.BaseOperation(
+          userId: nil,
+          userCertificateChain: nil,
+          userPrivateKey: nil,
+          lockId: lockUuid,
+          notBefore: now,
+          issuedAt: now,
+          expiresAt: now.addingTimeInterval(60),
+          jti: UUID()
+        )
 
-    doordeckSdk.lockOperations().unlock(unlockOperation: unlockOperation) { error in
-      if let error = error {
-        rejecter("UNLOCK_ERROR", error.localizedDescription, error)
-      } else {
+        let unlockOperation = LockOperations.UnlockOperation(baseOperation: baseOperation, directAccessEndpoints: nil)
+
+        try await sdk.lockOperations().unlock(unlockOperation: unlockOperation)
         resolver(nil)
+      } catch {
+        rejecter("UNLOCK_ERROR", error.localizedDescription, error)
       }
     }
   }
 
-  private func setKeyPairIfNeeded() {
-    if (!doordeckSdk.contextManager().isKeyPairValid()) {
-      let newKeyPair = doordeckSdk.crypto().generateKeyPair()
-      doordeckSdk.contextManager().setKeyPair(publicKey: newKeyPair.public_, privateKey: newKeyPair.private_)
+  private func setKeyPairIfNeeded(_ sdk: Doordeck) {
+    if (!sdk.contextManager().isKeyPairValid()) {
+      let newKeyPair = sdk.crypto().generateKeyPair()
+      sdk.contextManager().setKeyPair(publicKey: newKeyPair.public_, privateKey: newKeyPair.private_)
     }
   }
 
   private func respondNeedsVerification(
-    _ resolver: @escaping RCTPromiseResolveBlock,
-    _ rejecter: @escaping RCTPromiseRejectBlock
-  ) {
-    doordeckSdk.helper().assistedRegisterEphemeralKey(publicKey: nil) { response, error in
-      if let error = error {
-        rejecter("NEEDS_VERIFICATION_ERROR", error.localizedDescription, error)
-      } else if let response = response {
-        resolver(response.toNativeMap())
-      } else {
-        rejecter("NEEDS_VERIFICATION_ERROR", "Unknown error occurred", nil)
-      }
+    _ sdk: Doordeck,
+    _ resolver: @escaping RCTPromiseResolveBlock
+  ) async throws {
+    guard let response = try await sdk.helper().assistedRegisterEphemeralKey(publicKey: nil, privateKey: nil) else {
+      throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
     }
+    resolver(response.toNativeMap())
+  }
+
+  private static func makeError(_ message: String) -> NSError {
+    return NSError(
+      domain: "HeadlessReactNativeSdk",
+      code: -1,
+      userInfo: [NSLocalizedDescriptionKey: message]
+    )
   }
 }
 
@@ -188,9 +222,9 @@ extension AssistedRegisterEphemeralKeyResponse {
 extension TileLocksResponse {
   func toNativeMap() -> NSDictionary {
     return [
-      "siteId": siteId,
-      "tileId": tileId,
-      "deviceIds": deviceIds
+      "siteId": siteId.uuidString,
+      "tileId": tileId.uuidString,
+      "deviceIds": deviceIds.map { $0.uuidString }
     ]
   }
 }

--- a/ios/HeadlessReactNativeSdkImpl.swift
+++ b/ios/HeadlessReactNativeSdkImpl.swift
@@ -20,9 +20,7 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     if let existing = doordeckSdk {
       return existing
     }
-    guard let initialized = try await KDoordeckFactory().initialize(sdkConfig: SdkConfig.Builder().build()) else {
-      throw HeadlessReactNativeSdkImpl.makeError("Failed to initialize the Doordeck SDK")
-    }
+    let initialized = try await KDoordeckFactory().initialize(sdkConfig: SdkConfig.Builder().build())
     doordeckSdk = initialized
     return initialized
   }
@@ -116,7 +114,7 @@ public class HeadlessReactNativeSdkImpl: NSObject {
         resolver(response.toNativeMap(
           userId: contextManager.getUserId()?.uuidString,
           certificateChainAboutToExpire: contextManager.isCertificateChainInvalidOrExpired(),
-          tokenAboutToExpire: tokenAboutToExpire?.boolValue ?? false
+          tokenAboutToExpire: tokenAboutToExpire.boolValue
         ))
       } catch {
         rejecter("USER_DETAILS_ERROR", error.localizedDescription, error)
@@ -139,9 +137,7 @@ public class HeadlessReactNativeSdkImpl: NSObject {
           throw HeadlessReactNativeSdkImpl.makeError("Invalid tileId: \(tileId)")
         }
         let sdk = try await self.sdk()
-        guard let response = try await sdk.tiles().getLocksBelongingToTile(tileId: tileUuid) else {
-          throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
-        }
+        let response = try await sdk.tiles().getLocksBelongingToTile(tileId: tileUuid)
         resolver(response.toNativeMap())
       } catch {
         rejecter("LOCKS_ERROR", error.localizedDescription, error)
@@ -194,9 +190,7 @@ public class HeadlessReactNativeSdkImpl: NSObject {
     _ sdk: Doordeck,
     _ resolver: @escaping RCTPromiseResolveBlock
   ) async throws {
-    guard let response = try await sdk.helper().assistedRegisterEphemeralKey(publicKey: nil, privateKey: nil) else {
-      throw HeadlessReactNativeSdkImpl.makeError("Unknown error occurred")
-    }
+    let response = try await sdk.helper().assistedRegisterEphemeralKey(publicKey: nil, privateKey: nil)
     resolver(response.toNativeMap())
   }
 


### PR DESCRIPTION
## Problem

The example iOS build fails at Swift compile time:

```
[HeadlessReactNativeSdk] Compiling HeadlessReactNativeSdkImpl.swift
error: no such module 'DoordeckSDK'
import DoordeckSDK
```

This is **pre-existing** (it fails on every dependency PR; `build-android` stays green) and is unrelated to dependency versions — `pod install` *can* resolve `DoordeckSDK` from CocoaPods trunk (0.86 → 0.205). The native SDK has since moved to **SPM-delivered xcframeworks** ([`doordeck-headless-sdk-spm`](https://github.com/doordeck/doordeck-headless-sdk-spm), currently `v1.156.0`, wrapping xcframework `v0.205.0`), and the stale CocoaPods pod path no longer yields an importable Swift module in the example's static-linked Pods config.

## Change

Replace the CocoaPods `s.dependency "DoordeckSDK", "~> 0.86"` in `HeadlessReactNativeSdk.podspec` with React Native's built-in SPM helper (`spm_dependency`, RN ≥ 0.76 — this repo is on 0.77.1):

```ruby
spm_dependency(s,
  url: 'https://github.com/doordeck/doordeck-headless-sdk-spm.git',
  requirement: { kind: 'upToNextMajorVersion', minimumVersion: '1.156.0' },
  products: ['DoordeckSDK'])
```

The SPM product/module is also named `DoordeckSDK`, so `import DoordeckSDK` in the Swift bridge is unchanged. RN's `SPM.apply_on_post_install` adds the package to the failing `HeadlessReactNativeSdk` pod target and applies a `SWIFT_INCLUDE_PATHS` workaround — which targets exactly the failing compile unit.

## Open questions / follow-ups for review

- **Version pin**: I pinned `>= 1.156.0` (up-to-next-major) — the current SPM release. Adjust if you intend a specific native version.
- **Linkage**: RN warns SPM + static linking *may* cause linker errors and recommends `USE_FRAMEWORKS=dynamic`. I left the example on its default static linking for this first pass to get a clean CI signal; if a linker error surfaces, the follow-up is setting `USE_FRAMEWORKS=dynamic` for `pod install` + the build step in `pr.yml`.
- **Swift API compat**: the bridge code was written against the old native `0.86` API; if the current xcframework changed any symbols used in `ios/`, small bridge fixes may be needed (CI will reveal this).