### PR TITLE
chore(deps): upgrade activesupport to 7.2 and concurrent-ruby to 1.3.7

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,10 +1,12 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+# activesupport >= 7.2 requires Ruby >= 3.1.
+ruby ">= 3.1.0"
 
-# Exclude problematic versions of cocoapods and activesupport that causes build failures.
+# Exclude problematic versions of cocoapods that cause build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+# activesupport >= 7.2.3.1 patches CVE-2026-33169/33170/33176; < 8 keeps it on the
+# Ruby 3.1-compatible line and within cocoapods' supported range.
+gem 'activesupport', '>= 7.2.3.1', '< 8'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -5,12 +5,18 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.10)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
@@ -18,6 +24,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     claide (1.1.0)
     cocoapods (1.15.2)
       addressable (~> 2.8)
@@ -57,7 +65,9 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.7)
+    connection_pool (3.0.2)
+    drb (2.2.3)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -67,10 +77,11 @@ GEM
     gh_inspector (1.1.3)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     json (2.7.6)
-    minitest (5.25.4)
+    logger (1.7.0)
+    minitest (5.27.0)
     molinillo (0.8.0)
     mutex_m (0.3.0)
     nanaimo (0.3.0)
@@ -80,6 +91,7 @@ GEM
     public_suffix (4.0.7)
     rexml (3.4.4)
     ruby-macho (2.5.1)
+    securerandom (0.4.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
@@ -91,19 +103,17 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (>= 3.3.6, < 4.0)
-    zeitwerk (2.6.18)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.5, != 7.1.0)
+  activesupport (>= 7.2.3.1, < 8)
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
   xcodeproj (< 1.26.0)
 
 RUBY VERSION
-   ruby 2.6.10p210
+   ruby 3.3.11p205
 
 BUNDLED WITH
-   2.1.4
+   2.5.22


### PR DESCRIPTION
## Summary

Clears **6** Dependabot alerts on the example app's iOS CocoaPods tooling — the largest remaining cluster, including the only **High**:

| Alert | Package | Was → Now | Severity |
|---|---|---|---|
| [#64](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/64) | activesupport | 6.1.7.10 → 7.2.3.1 | Moderate (XSS) |
| [#65](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/65) | activesupport | ″ | Moderate (ReDoS) |
| [#66](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/66) | activesupport | ″ | Moderate (DoS) |
| [#107](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/107) | concurrent-ruby | 1.3.3 → 1.3.7 | **High** (livelock) |
| [#108](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/108) | concurrent-ruby | ″ | Low |
| [#109](https://github.com/doordeck/doordeck-headless-sdk-react-native/security/dependabot/109) | concurrent-ruby | ″ | Low |

## Changes (`example/`)

- **activesupport → 7.2.3.1.** Its only patched line requires **Ruby ≥ 3.1**, so the Gemfile `ruby` directive is bumped to `>= 3.1.0`.
- **Dropped the `concurrent-ruby < 1.3.4` cap.** That cap was a workaround for activesupport **6.1**'s missing-`logger` breakage with concurrent-ruby ≥ 1.3.4. activesupport 7.x declares `logger` as a dependency, so the cap is no longer needed and concurrent-ruby floats to 1.3.7.
- `Gemfile.lock` regenerated (activesupport 7.2 pulls in `logger`, `drb`, `connection_pool`, `bigdecimal`, `benchmark`, `securerandom`; drops `zeitwerk`). `PLATFORMS: ruby` preserved.

## Verification

Generated and validated in a `ruby:3.3` container (system Ruby here is 2.6):
- `bundle install --frozen` → lockfile consistent, installs on Ruby 3.x ✅
- `pod --version` runs under activesupport 7.2.3.1 + concurrent-ruby 1.3.7 → **cocoapods 1.15.2 compatibility confirmed** ✅

> Note: the iOS CI job runs `pod install --repo-update` with the macOS runner's own Ruby/CocoaPods and does **not** consume this `Gemfile.lock` (no `bundle exec`), so `build-ios` is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)